### PR TITLE
ParseAndRun doesn't always check args

### DIFF
--- a/command.go
+++ b/command.go
@@ -25,6 +25,8 @@ func (s *Service) initCommand() {
 	s.RegisterCommand("update", "Update service files if update url is provided", wrapFunc(s.Update), 0)
 }
 
+// RegisterCommand registers command according to name, and it will check the number of arguments
+// if args is not a negative number.
 func (s *Service) RegisterCommand(name, usage string, fn func(arg ...string) error, args int) {
 	name = strings.ToLower(name)
 	if _, ok := s.m[name]; !ok {
@@ -33,6 +35,7 @@ func (s *Service) RegisterCommand(name, usage string, fn func(arg ...string) err
 	s.m[name] = command{fn, args, usage}
 }
 
+// ParseAndRun parses args and runs the service.
 func (s *Service) ParseAndRun(args []string) error {
 	if IsWindowsService() {
 		return s.Run()
@@ -43,7 +46,7 @@ func (s *Service) ParseAndRun(args []string) error {
 		return s.Run()
 	default:
 		if cmd, ok := s.m[strings.ToLower(args[0])]; ok && cmd.fn != nil {
-			if a := args[1:]; len(a) == cmd.args {
+			if a := args[1:]; cmd.args < 0 || len(a) == cmd.args {
 				return cmd.fn(a...)
 			} else {
 				return fmt.Errorf("%s need %d arguments", args[0], cmd.args)
@@ -53,6 +56,7 @@ func (s *Service) ParseAndRun(args []string) error {
 	}
 }
 
+// Usage returns service usage.
 func (s *Service) Usage() string {
 	var b strings.Builder
 	b.WriteString("\nservice command:\n")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sunshineplan/service
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/sunshineplan/utils v0.1.51

--- a/service.go
+++ b/service.go
@@ -9,7 +9,8 @@ import (
 	"github.com/sunshineplan/utils/log"
 )
 
-var ErrNoExcute = errors.New("service execute is not defined")
+// ErrNoExcute is the error returned when the service execute is not specified.
+var ErrNoExcute = errors.New("service execute is not specified")
 
 var defaultName = "Service"
 
@@ -48,6 +49,7 @@ func New() *Service {
 	return svc
 }
 
+// SetLogger sets service's log file.
 func (s *Service) SetLogger(file, prefix string, flag int) *Service {
 	s.Logger = log.New(file, prefix, flag)
 	return s


### PR DESCRIPTION
ParseAndRun doesn't check the number of arguments if RegisterCommand's args is a negative number.